### PR TITLE
Only consider Java sources when determining if a sourceset has sourcefiles.

### DIFF
--- a/src/main/groovy/aspectj/AspectJPlugin.groovy
+++ b/src/main/groovy/aspectj/AspectJPlugin.groovy
@@ -44,13 +44,13 @@ class AspectJPlugin implements Plugin<Project> {
             }
         }
 
-        if (!project.sourceSets.main.allSource.isEmpty()) {
+        if (!project.sourceSets.main.allJava.isEmpty()) {
             project.tasks.create(name: 'compileAspect', overwrite: true, description: 'Compiles AspectJ Source', type: Ajc) {
                 dependsOn project.configurations*.getTaskDependencyFromProjectDependency(true, "compileJava")
 
                 dependsOn project.processResources
                 sourceSet = project.sourceSets.main
-                inputs.files(sourceSet.allSource)
+                inputs.files(sourceSet.allJava)
                 outputs.dir(sourceSet.output.classesDir)
                 aspectPath = project.configurations.aspectpath
                 ajInpath = project.configurations.ajInpath
@@ -60,11 +60,11 @@ class AspectJPlugin implements Plugin<Project> {
             project.tasks.compileJava.dependsOn project.tasks.compileAspect
         }
 
-        if (!project.sourceSets.test.allSource.isEmpty()) {
+        if (!project.sourceSets.test.allJava.isEmpty()) {
             project.tasks.create(name: 'compileTestAspect', overwrite: true, description: 'Compiles AspectJ Test Source', type: Ajc) {
                 dependsOn project.processTestResources, project.compileJava
                 sourceSet = project.sourceSets.test
-                inputs.files(sourceSet.allSource)
+                inputs.files(sourceSet.allJava)
                 outputs.dir(sourceSet.output.classesDir)
                 aspectPath = project.configurations.testAspectpath
                 ajInpath = project.configurations.testAjInpath


### PR DESCRIPTION
Fixes #7.
