### PR TITLE
add maxmem config option in compile tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ compileAspect {
 }
 ```
 
-Also by default, the ajc ant task will be forked with a maximum JVM heap size of 128MB. Specify a different value for the `maxmem` variable of the `compileAspect` or
+Also by default, the ajc ant task will be forked with a maximum JVM heap size of 124MB. Specify a different value for the `maxmem` variable of the `compileAspect` or
 `compileTestAspect` task to increase or decrease the max heap size.
 
 ```groovy

--- a/src/main/groovy/aspectj/AspectJPlugin.groovy
+++ b/src/main/groovy/aspectj/AspectJPlugin.groovy
@@ -83,8 +83,14 @@ class Ajc extends DefaultTask {
     FileCollection aspectPath
     FileCollection ajInpath
 
+    // ignore or warning
     String xlint = 'ignore'
-    String maxmem = '128m'
+
+    // defaulted to 124m based on
+    //     java -XX:+PrintFlagsFinal -version 2> /dev/null | \
+    //         grep MaxHeapSize | awk '{print $4}' | \
+    //         xargs -I{} echo {}/1024/1024 | bc
+    String maxmem = '124m'
 
     Ajc() {
         logging.captureStandardOutput(LogLevel.INFO)


### PR DESCRIPTION
provide quick and easy config option support to configure the heapsize of the forked ant task. it's equivalent to adding `-Xmx128m` to the arguments passed to the aspect compiler.

i set a default of 124m, because my machine appears to have a default max of 124m for a normal vm.

``` bash
java -XX:+PrintFlagsFinal -version 2> /dev/null | \
    grep MaxHeapSize | awk '{print $4}' | xargs -I{} echo {}/1024/1024 | bc
```
