### PR TITLE
add support for multiple source sets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
+apply plugin: 'idea'
 
 group = 'nl.eveoh'
 version = '1.5'

--- a/src/main/groovy/aspectj/NamingConventions.groovy
+++ b/src/main/groovy/aspectj/NamingConventions.groovy
@@ -1,0 +1,14 @@
+package aspectj
+
+import org.gradle.api.tasks.SourceSet
+
+public interface NamingConventions {
+
+    String getJavaCompileTaskName(SourceSet sourceSet);
+
+    String getAspectCompileTaskName(SourceSet sourceSet);
+
+    String getAspectPathConfigurationName(SourceSet sourceSet);
+
+    String getAspectInpathConfigurationName(SourceSet sourceSet);
+}


### PR DESCRIPTION
The idea is to be able to use ajc against source sets other than `main` and `test`. Again wasn't sure how much we care about backwards compatibility, but this should at least leave `main` and `test` intact.  
