### PR TITLE
Set annotation processor output to target output directory

### DIFF
--- a/src/main/groovy/aspectj/AspectJPlugin.groovy
+++ b/src/main/groovy/aspectj/AspectJPlugin.groovy
@@ -135,6 +135,7 @@ class Ajc extends DefaultTask {
 
         def iajcArgs = [classpath           : sourceSet.compileClasspath.asPath,
                         destDir             : sourceSet.output.classesDir.absolutePath,
+                        s                   : sourceSet.output.classesDir.absolutePath,
                         source              : project.convention.plugins.java.sourceCompatibility,
                         target              : project.convention.plugins.java.targetCompatibility,
                         inpath              : ajInpath.asPath,


### PR DESCRIPTION
By default annotation processor output directory for javac is same as target output directory (like project/build/classes/main/). But for ajc by default annotation processor output directory is current directory (like project/).

Annotation processor output is defined by "-s" option.

Option "-s" is described in manual: http://docs.oracle.com/javase/6/docs/technotes/tools/windows/javac.html, but AJC also support this option:

```
-s dir
        Specify the directory where to place generated source files. The directory must already exist; javac will not create it.
        If a class is part of a package, the compiler puts the source file in a subdirectory reflecting the package name, creating directories as needed.
        For example, if you specify -s C:\mysrc and the class is called com.mypackage.MyClass, then the source file will be placed in C:\mysrc\com\mypackage\MyClass.java.
```