### PR TITLE
Gradle 4 deprecation warning

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-4.1-bin.zip

--- a/src/main/groovy/aspectj/AspectJPlugin.groovy
+++ b/src/main/groovy/aspectj/AspectJPlugin.groovy
@@ -47,7 +47,7 @@ class AspectJPlugin implements Plugin<Project> {
                 project.tasks.create(name: aspectTaskName, overwrite: true, description: "Compiles AspectJ Source for ${projectSourceSet.name} source set", type: Ajc) {
                     sourceSet = projectSourceSet
                     inputs.files(sourceSet.allJava)
-                    outputs.dir(sourceSet.output.classesDir)
+                    outputs.dir(sourceSet.java.outputDir)
                     aspectpath = project.configurations.findByName(namingConventions.getAspectPathConfigurationName(projectSourceSet))
                     ajInpath = project.configurations.findByName(namingConventions.getAspectInpathConfigurationName(projectSourceSet))
                 }
@@ -134,8 +134,8 @@ class Ajc extends DefaultTask {
         logger.info("srcDirs $sourceSet.java.srcDirs")
 
         def iajcArgs = [classpath           : sourceSet.compileClasspath.asPath,
-                        destDir             : sourceSet.output.classesDir.absolutePath,
-                        s                   : sourceSet.output.classesDir.absolutePath,
+                        destDir             : sourceSet.java.outputDir.absolutePath,
+                        s                   : sourceSet.java.outputDir.absolutePath,
                         source              : project.convention.plugins.java.sourceCompatibility,
                         target              : project.convention.plugins.java.targetCompatibility,
                         inpath              : ajInpath.asPath,


### PR DESCRIPTION
As of Gradle 4.0+, using this plugin generates the following warning:

> Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set. This behaviour has been deprecated and is scheduled to be removed in Gradle 5.0

This pull request fixes it by replacing all calls to the now-deprecated `SourceSetOutput#getClassesDir` method.