### PR TITLE
Move the aspectj lib dependency evaluation to a `project.afterEvaluate` closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ Usage
 -----
 
 Either build this project yourself, and include the `.jar` in your buildscript dependencies,
-or use our Maven repo. Then set `ext.aspectjVersion` to your AspectJ version and `apply plugin: 'aspectj'`.
+or use our Maven repo. The plugin is applied using `apply plugin: 'aspectj'`. 
+The version of AspectJ to use can be defined using either `ext.aspectjVersion`, 
+or the `aspectj` extension's `version` attribute. 
+If the AspectJ version is not set, version `1.8.12` is used as the default.
+
 Something like this:
 
 ```groovy
@@ -25,11 +29,16 @@ repositories {
     mavenCentral()
 }
 
-project.ext {
-    aspectjVersion = '1.8.4'
-}
-
 apply plugin: 'aspectj'
+
+// Optionally
+project.ext {
+    aspectjVersion = '1.8.12'
+}
+// Or
+aspectj {
+    version = '1.8.12'
+}
 ```
 
 Note that version 2.0+ is only compatible with Gradle 4+. Use version 1.6 for earlier Gradle versions.

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 
 group = 'nl.eveoh'
-version = '2.0'
+version = '2.1'
 
 repositories {
     maven {

--- a/src/main/groovy/aspectj/AspectJPlugin.groovy
+++ b/src/main/groovy/aspectj/AspectJPlugin.groovy
@@ -20,15 +20,19 @@ class AspectJPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.plugins.apply(JavaPlugin)
 
-        if (!project.hasProperty('aspectjVersion')) {
-            throw new GradleException("You must set the property 'aspectjVersion' before applying the aspectj plugin")
-        }
+        def aspectj = project.extensions.create('aspectj', AspectJExtension, project)
 
         if (project.configurations.findByName('ajtools') == null) {
             project.configurations.create('ajtools')
-            project.dependencies {
-                ajtools "org.aspectj:aspectjtools:${project.aspectjVersion}"
-                compile "org.aspectj:aspectjrt:${project.aspectjVersion}"
+            project.afterEvaluate { p ->
+                if (aspectj.version == null) {
+                    throw new GradleException("No aspectj version supplied")
+                }
+
+                p.dependencies {
+                    ajtools "org.aspectj:aspectjtools:${aspectj.version}"
+                    compile "org.aspectj:aspectjrt:${aspectj.version}"
+                }
             }
         }
 
@@ -164,5 +168,14 @@ class Ajc extends DefaultTask {
                 }
             }
         }
+    }
+}
+
+class AspectJExtension {
+
+    String version
+
+    AspectJExtension(Project project) {
+        this.version = project.findProperty('aspectjVersion') ?: '1.8.12'
     }
 }


### PR DESCRIPTION
This removes the requirement for the aspectj version to be specified before applying the plugin.

I've also introduced an Extension, adhering more to the Gradle convention for configuring plugins. The Extension's `version` is initialised with the existing `aspectjVersion` project property, to allow for backwards compatibility with `2.0`. If no configuration is provided, then a default value of `1.8.12` is used.

Updated the README with an example usage of the extension.